### PR TITLE
Split dependencies into subpackage extras and add [All] meta extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,42 +23,59 @@ classifiers = [
     "Topic :: Text Processing :: General",
 ]
 dependencies = [
-    "docling<=2.34.0",
-    "easyocr<=1.7.2",
-    "faiss-cpu>=1.11.0",
-    "langchain-core<=0.3.61",
-    "langchain-text-splitters<=0.3.8",
-    "markitdown[all]<=0.1.1",
-    "pandas<=2.2.3",
-    "pdf2image<=1.17.0",
-    "pillow<=10.4.0", # For pytesseract and surya-ocr
-    "pymupdf<=1.26.0",
-    "pytesseract<=0.3.13",
     "pythainlp<=5.1.2",
-    "python-doctr[torch]>=0.12.0",
     "python-magic<=0.4.27",
-    "scikit-learn>=1.6.1",
     "sentence-transformers>=4.1.0",
     "spacy<=3.8.7",
-    "surya-ocr<=0.14.2",
-    "tiktoken>=0.9.0",
-    "torch<=2.7.0", # Pinned to CPU wheel version
-    "torchaudio<=2.7.0", # Pinned to CPU wheel version
-    "torchvision<=0.22.0", # Pinned to CPU wheel version
     "transformers<=4.52.3",
 ]
 
 [project.optional-dependencies]
-dev = [
+Kornja = [
+    "langchain-text-splitters<=0.3.8",
+    "tiktoken>=0.9.0",
+]
+
+WichienMaat = [
+    "faiss-cpu>=1.11.0",
+    "langchain-core<=0.3.61",
+    "pandas<=2.2.3",
+    "scikit-learn>=1.6.1",
+    "numpy>=1.24.0",
+]
+
+KhaoManee = [
+    "torch<=2.7.0", # Pinned to CPU wheel version
+    "torchvision<=0.22.0", # Pinned to CPU wheel version
+    "torchaudio<=2.7.0", # Pinned to CPU wheel version
+]
+
+Malet = [
+    "docling<=2.34.0",
+    "markitdown[all]<=0.1.1",
+    "pdf2image<=1.17.0",
+    "pillow<=10.4.0", # For pytesseract and surya-ocr
+    "pymupdf<=1.26.0",
+    "easyocr<=1.7.2",
+    "pytesseract<=0.3.13",
+    "python-doctr[torch]>=0.12.0",
+    "surya-ocr<=0.14.2",
+]
+
+Dev = [
     "pytest<=8.3.5",
     "ipykernel>=6.29.5",
     "ipywidgets>=8.1.7",
     "jupyterlab-widgets>=3.0.15",
 ]
-docs = [
+Docs = [
     "sphinx<=8.2.3",
     "furo<=2024.8.6",
     "sphinx-copybutton>=0.5.2",
+]
+
+All = [
+    "purrfectkit[Kornja,WichienMaat,KhaoManee,Malet,Dev,Docs]"
 ]
 
 [project.urls]


### PR DESCRIPTION
### Summary
This PR refactors dependency management in `pyproject.toml`:
- Split heavy dependencies into optional extras per subpackage (`Kornja`, `WichienMaat`, `KhaoManee`, `sawat`)
- Added `[all]` meta extra for installing the full stack with a single command
- Keeps core package dependency-free by default

### Usage
- Core only: `pip install .`
- Install subpackage deps selectively:  
  - `pip install .[sawat]`  
  - `pip install .[plort]`
- Install everything:  
  - `pip install .[all]`

### Motivation
- Avoids installing heavy deps unnecessarily (e.g., OCR, FAISS, Transformers, Torch)
- Lets projects include only what they need
- Provides convenience `[all]` target for full installation

Closes #7 
